### PR TITLE
[BUGFIX] DTPORTAL-16140: Fix quick asterisk command hanging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # develop
   * Feature: Add #sip_remove_header to complement #sip_add_header, to remove a specific header that was previously added
+  * Bugfix: Prevent quick Asterisk commands from hanging indefinitely by using supported `#execute_agi_command` in Adhearsion.
 
 # v1.5.1
   * Remove dependency on activesupport

--- a/lib/adhearsion/asterisk/call_controller_methods.rb
+++ b/lib/adhearsion/asterisk/call_controller_methods.rb
@@ -431,8 +431,7 @@ module Adhearsion
       # careful handling immutable objects outside the scope. If you're unsure, don't use a block.
       #
       def generate_silence(&block)
-        component = Adhearsion::Rayo::Component::Asterisk::AGI::Command.new :name => "EXEC Playtones", :params => ["0"]
-        execute_component_and_await_completion component
+        execute 'Playtones', '0'
         GenerateSilenceProxy.proxy_for(self, &block) if block_given?
       end
 

--- a/lib/adhearsion/asterisk/call_controller_methods.rb
+++ b/lib/adhearsion/asterisk/call_controller_methods.rb
@@ -17,11 +17,11 @@ module Adhearsion
       } unless defined? DYNAMIC_FEATURE_EXTENSIONS
 
       def agi(name, *params)
-        component = Adhearsion::Rayo::Component::Asterisk::AGI::Command.new :name => name, :params => params
-        execute_component_and_await_completion component
-        complete_reason = component.complete_event.reason
-        raise Adhearsion::Call::Hangup if complete_reason.is_a?(Adhearsion::Event::Complete::Hangup)
-        [:code, :result, :data].map { |p| complete_reason.send p }
+        connection = Adhearsion::Rayo::Initializer.connection
+        asterisk_call = connection.translator.call_with_id call.id
+        raise Adhearsion::Call::Hangup unless asterisk_call
+        event_hash = asterisk_call.execute_agi_command(name, *params) || raise(Adhearsion::Call::Hangup)
+        event_hash.fetch_values :code, :result, :data
       end
 
       #

--- a/spec/adhearsion/asterisk/call_controller_methods_spec.rb
+++ b/spec/adhearsion/asterisk/call_controller_methods_spec.rb
@@ -516,8 +516,7 @@ module Adhearsion::Asterisk
       describe '#generate_silence' do
         context 'executes Playtones with 0 as an argument if it' do
           before do
-            command = Adhearsion::Rayo::Component::Asterisk::AGI::Command.new :name => "EXEC Playtones", :params => ["0"]
-            @expect_command = subject.should_receive(:execute_component_and_await_completion).with(command)
+            @expect_command = subject.should_receive(:execute).once.with('Playtones', '0')
           end
 
           it 'is not given a block' do

--- a/spec/adhearsion/asterisk/call_controller_methods_spec.rb
+++ b/spec/adhearsion/asterisk/call_controller_methods_spec.rb
@@ -4,41 +4,43 @@ module Adhearsion::Asterisk
   describe CallControllerMethods do
     describe "mixed in to a CallController" do
 
-      let(:call) { double('Call') }
+      let(:call_id) { 'call-id-12345' }
+      let(:call) { double('Call', id: call_id) }
 
       subject { Adhearsion::CallController.new call }
 
       before { Adhearsion::CallController.mixin CallControllerMethods }
 
       describe '#agi' do
-        let :expected_agi_command do
-          Adhearsion::Rayo::Component::Asterisk::AGI::Command.new :name => 'Dial', :params => ['4044754842', 15]
-        end
+        let(:expected_agi_command) { ['Dial', '4044754842', 15] }
+        let(:complete_result) { { :code => 200, :result => 1, :data => 'foobar' } }
+        let(:mock_asterisk_translator_call) { double 'Asterisk Translator Call', execute_agi_command: complete_result }
+        let(:mock_asterisk_translator) { double 'Asterisk Translator', call_with_id: mock_asterisk_translator_call }
+        let(:mock_client_connection) { double 'Rayo Client Connection', translator: mock_asterisk_translator }
 
-        let :complete_event do
-          Adhearsion::Event::Complete.new.tap do |c|
-            c.reason = Adhearsion::Rayo::Component::Asterisk::AGI::Command::Complete::Success.new :code => 200, :result => 1, :data => 'foobar'
-          end
-        end
-
-        before { Adhearsion::Rayo::Component::Asterisk::AGI::Command.any_instance.stub :complete_event => complete_event }
+        before { allow(Adhearsion::Rayo::Initializer).to receive(:connection).once.and_return mock_client_connection }
 
         it 'should execute an AGI command with the specified name and parameters and return the response code, response and data' do
-          subject.should_receive(:execute_component_and_await_completion).once.with expected_agi_command
+          mock_asterisk_translator_call.should_receive(:execute_agi_command).once.with(*expected_agi_command).and_return complete_result
           values = subject.agi 'Dial', '4044754842', 15
           values.should == [200, 1, 'foobar']
         end
 
         context 'when AGI terminates because of a hangup' do
-          let :complete_event do
-            Adhearsion::Event::Complete.new.tap do |c|
-              c.reason = Adhearsion::Event::Complete::Hangup.new
+          shared_examples 'honoring a Hangup' do
+            it 'should raise Adhearsion::Call::Hangup' do
+              lambda { subject.agi 'Dial', '4044754842', 15 }.should raise_error(Adhearsion::Call::Hangup)
             end
           end
 
-          it 'should raise Adhearsion::Call::Hangup' do
-            subject.should_receive(:execute_component_and_await_completion).once.with expected_agi_command
-            lambda { subject.agi 'Dial', '4044754842', 15 }.should raise_error(Adhearsion::Call::Hangup)
+          context 'when #execute_agi_command raises a Hangup' do
+            before { mock_asterisk_translator_call.should_receive(:execute_agi_command).once.with(*expected_agi_command).and_raise Adhearsion::Call::Hangup }
+            it_behaves_like 'honoring a Hangup'
+          end
+
+          context 'when #execute_agi_command returns nil' do
+            before { mock_asterisk_translator_call.should_receive(:execute_agi_command).once.with(*expected_agi_command).and_return nil }
+            it_behaves_like 'honoring a Hangup'
           end
         end
       end


### PR DESCRIPTION
### Problem

Examples like the following easily lead to #execute hanging indefinitely:

```ruby
100.times do |i|
  execute 'StopMonitor'
  logger.info "execute round #{i} DONE!"
end
```
#### Output:

    execute round 0 DONE!
    execute round 1 DONE!
    execute round 2 DONE!
    execute round 3 DONE!
    execute round 4 DONE!

_(... tumbleweed ...)_


### Cause

Use of `Adhearsion::Rayo::Component::Asterisk::AGI::Command` as a Component to execute Asterisk AGI commands which return quickly (in sub-second time) can lead to a race condition where a Command hangs indefinitely.  This happens because execution of a `Adhearsion::Rayo::Component::Asterisk::AGI::Command.new` [is handled by](https://github.com/adhearsion/adhearsion/blob/v3.0.0.rc1/lib/adhearsion/translator/asterisk/call.rb#L265-L266)
`Adhearsion::Translator::Asterisk::Component::Asterisk::AGICommand`, [which executes the AGI command asynchronously while registering its component](https://github.com/adhearsion/adhearsion/blob/v3.0.0.rc1/lib/adhearsion/translator/asterisk/component/asterisk/agi_command.rb#L14-L15) .  Complete Events received from Asterisk for commands that finish nearly instantly often found the events dropped on the floor, because the
component was not yet registered in the `Adhearsion::Rayo::Client::ComponentRegistry`. The outcome in such a case was that `#execute` would hang indefinitely, waiting forever for a Complete Event which was received long ago.

### Resolution

This change abandons use of `Adhearsion::Rayo::Component::Asterisk::AGI::Command` of as a Component (a racey approach used only by adhearsion-asterisk, by the way).  This is replaced by use of Adhearsion's preferred `#execute_agi_command`.